### PR TITLE
feat(api): add health check endpoint

### DIFF
--- a/taskboard/src/main/java/com/eddy/taskboard/system/HealthController.java
+++ b/taskboard/src/main/java/com/eddy/taskboard/system/HealthController.java
@@ -4,5 +4,23 @@ package com.eddy.taskboard.system;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * HealthController
+ * ----------------
+ * A simple REST controller that exposes a health check endpoint.
+ * Used by developers or monitoring tools to verify that the app is running.
+ */
+
+@RestController
 public class HealthController {
+
+    /**
+     * GET /api/v1/health
+     * -------------------
+     * Returns a simple "OK" message to confirm the service is up.
+     */
+    @GetMapping("/api/v1/health")
+    public String healthCheck() {
+        return "OK";
+    }
 }


### PR DESCRIPTION
## Summary
Added a HealthController for /api/v1/health and updated SecurityConfig to allow
public access to health and Swagger endpoints.

## Linked issue
Closes #1

## How to test
- Run `./gradlew bootRun`
- Visit `http://localhost:8080/api/v1/health` → should return "OK"
- Visit `http://localhost:8080/swagger-ui.html` → should load without login

## Checklist
- [x] Feature tested locally
- [x] Uses conventional commit style
- [x] Linked to related issue