### PR TITLE
fix(db): relax foreign key constraint on workspaces.created_by

### DIFF
--- a/taskboard/src/main/resources/db/migration/V2__relax_created_by_fk.sql
+++ b/taskboard/src/main/resources/db/migration/V2__relax_created_by_fk.sql
@@ -1,0 +1,6 @@
+-- V2__relax_created_by_fk.sql
+ALTER TABLE workspaces
+DROP CONSTRAINT IF EXISTS workspaces_created_by_fkey;
+
+ALTER TABLE workspaces
+    ALTER COLUMN created_by DROP NOT NULL;


### PR DESCRIPTION
### Summary
This pull request introduces a Flyway migration to relax the foreign key constraint on the `workspaces.created_by` column.  
It allows workspace creation before the user management feature is implemented.

---

### Linked Issue
Closes #3

---

### How to Test
1. Run:
  ```bash
  ./gradlew bootRun
  ```
2. Send a request:
  ```bash
  curl -u eddy:eddy123 -H "Content-Type: application/json" \
  -d '{"name": "My Test Workspace"}' \
  http://localhost:8080/api/v1/workspaces
  ```
 4. Verify the workspace is created successfully (no 500 error).
 
 ---
 
 ### Checklist
- [x] Added Flyway migration file `V2__relax_created_by_fk.sql`
- [x] Tested workspace creation manually
- [x] Linked issue #3
- [x] Uses proper commit message format
